### PR TITLE
Dot net core3.1

### DIFF
--- a/LazZiya.TagHelpers/AlertTagHelper.cs
+++ b/LazZiya.TagHelpers/AlertTagHelper.cs
@@ -28,10 +28,9 @@ namespace LazZiya.TagHelpers
         public bool Dismissable { get; set; } = true;
 
         /// <summary>
-        /// <para>ViewContext property is not required any more to be passed as parameter, you can remove it from the code.</para>
+        /// <para>ViewContext property is not required to be passed as parameter, it will be assigned automatically by the tag helper.</para>
         /// <para>View context is required to access TempData dictionary that contains the alerts coming from backend</para>
         /// </summary>
-        [Obsolete("ViewContext property is not required any more to be passed as parameter, you can remove it from the code. ")]
         [ViewContext]
         public ViewContext ViewContext { get; set; } = null;
 

--- a/LazZiya.TagHelpers/Alerts/AlertPageModelExtensions.cs
+++ b/LazZiya.TagHelpers/Alerts/AlertPageModelExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using LazZiya.TagHelpers.Utilities;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
-#if NETCOREAPP3_0
+#if NETCOREAPP3_0 || NETCOREAPP3_1
 using System.Text.Json;
 #else
 using Newtonsoft.Json;
@@ -112,7 +112,7 @@ namespace LazZiya.TagHelpers.Alerts
 
         private static void AddAlert(ITempDataDictionary tempData, AlertStyle alertStyle, string message, string header, bool dismissable)
         {
-#if NETCOREAPP3_0
+#if NETCOREAPP3_0 || NETCOREAPP3_1
             var alerts = tempData.ContainsKey(Alert.TempDataKey)
                 ? JsonSerializer.Deserialize<List<Alert>>(tempData[Alert.TempDataKey].ToString())
                 : new List<Alert>();

--- a/LazZiya.TagHelpers/LanguageNavTagHelper.cs
+++ b/LazZiya.TagHelpers/LanguageNavTagHelper.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
-#if NETCOREAPP2_2 || NETCOREAPP3_0
+#if NETCOREAPP2_2 || NETCOREAPP3_0 || NETCOREAPP3_1
 using Microsoft.AspNetCore.Routing;
 #endif
 
@@ -54,10 +54,9 @@ namespace LazZiya.TagHelpers
         public string HomePageName { get; set; } = "Index";
 
         /// <summary>
-        /// <para>ViewContext property is not required any more to be passed as parameter, you can remove it from the code.</para>
+        /// <para>ViewContext property is not required to be passed as parameter, it will be auto assigned by the tag helpoer.</para>
         /// <para>current view context to access RouteData.Values and Request.Query collection</para>
         /// </summary>
-        [Obsolete("ViewContext property is not required any more to be passed as parameter, you can remove it from the code. ")]
         [ViewContext]
         public ViewContext ViewContext { get; set; }
 
@@ -71,9 +70,9 @@ namespace LazZiya.TagHelpers
         /// </summary>
         private readonly IOptions<RequestLocalizationOptions> _ops;
         private readonly ILogger _logger;
-        
-        
-#if NETCOREAPP2_2 || NETCOREAPP3_0
+
+
+#if NETCOREAPP2_2 || NETCOREAPP3_0 || NETCOREAPP3_1
         private readonly IOptions<MvcOptions> _mvcOps;
         private readonly LinkGenerator _lg;
 
@@ -218,7 +217,7 @@ namespace LazZiya.TagHelpers
                 // DotNetCore 2.2 uses EndPointRouting, 
                 // so we need to use the link generator to generate url
                 url = _lg.GetPathByRouteValues(httpContext: ViewContext.HttpContext, "", _routeData);
-#elif NETCOREAPP3_0
+#elif NETCOREAPP3_0 || NETCOREAPP3_1
                 // DotNetCore 3.0 has optional value to use EndPointRouting
                 // First check if EndPointRouting is enabled
                 // Or use generic urlHelper to generate url

--- a/LazZiya.TagHelpers/LanguageNavTagHelper.cs
+++ b/LazZiya.TagHelpers/LanguageNavTagHelper.cs
@@ -69,8 +69,6 @@ namespace LazZiya.TagHelpers
         /// required for listing supported cultures
         /// </summary>
         private readonly IOptions<RequestLocalizationOptions> _ops;
-        private readonly ILogger _logger;
-
 
 #if NETCOREAPP2_2 || NETCOREAPP3_0 || NETCOREAPP3_1
         private readonly IOptions<MvcOptions> _mvcOps;
@@ -79,13 +77,11 @@ namespace LazZiya.TagHelpers
         /// <summary>
         /// creates a language navigation menu, depends on supported cultures
         /// </summary>
-        /// <param name="logger"></param>
         /// <param name="ops">Request localization options</param>
         /// <param name="lg">link generator</param>
         /// <param name="mvcOps">MvcOptions</param>
-        public LanguageNavTagHelper(ILogger<LanguageNavTagHelper> logger, IOptions<RequestLocalizationOptions> ops, LinkGenerator lg, IOptions<MvcOptions> mvcOps)
+        public LanguageNavTagHelper(IOptions<RequestLocalizationOptions> ops, LinkGenerator lg, IOptions<MvcOptions> mvcOps)
         {
-            _logger = logger;
             _ops = ops;
             _lg = lg;
             _mvcOps = mvcOps;
@@ -94,11 +90,9 @@ namespace LazZiya.TagHelpers
         /// <summary>
         /// creates a language navigation menu, depends on supported cultures
         /// </summary>
-        /// <param name="logger"></param>
         /// <param name="ops"></param>
-        public LanguageNavTagHelper(ILogger<LanguageNavTagHelper> logger, IOptions<RequestLocalizationOptions> ops)
+        public LanguageNavTagHelper(IOptions<RequestLocalizationOptions> ops)
         {
-            _logger = logger;
             _ops = ops;
         }
 #endif

--- a/LazZiya.TagHelpers/LazZiya.TagHelpers.csproj
+++ b/LazZiya.TagHelpers/LazZiya.TagHelpers.csproj
@@ -16,7 +16,7 @@
       - Support for dot net core 3.1.0
       - PagingTagHelper : QueryStringValue is Obsolete, replaced by auto assigned ViewContext
     </PackageReleaseNotes>
-    <Version>3.1.0-preview1</Version>
+    <Version>3.1.0-preview2</Version>
     <AssemblyVersion>3.1.0.0</AssemblyVersion>
     <FileVersion>3.1.0.0</FileVersion>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/LazZiya.TagHelpers/LazZiya.TagHelpers.csproj
+++ b/LazZiya.TagHelpers/LazZiya.TagHelpers.csproj
@@ -13,8 +13,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageTags>asp.net, core, razor, mvc, taghelpers, taghelper,tag,helper,language,culture,dropdown, pagination, select, enum</PackageTags>
     <PackageReleaseNotes>
-      - Support for dot net core 3.1.0
-      - PagingTagHelper : QueryStringValue is Obsolete, replaced by auto assigned ViewContext
+      - PagingTagHelper : New default values, all options are on, switch off manually if not needed.
     </PackageReleaseNotes>
     <Version>3.1.0-preview2</Version>
     <AssemblyVersion>3.1.0.0</AssemblyVersion>

--- a/LazZiya.TagHelpers/LazZiya.TagHelpers.csproj
+++ b/LazZiya.TagHelpers/LazZiya.TagHelpers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <ApplicationIcon>files\icon.ico</ApplicationIcon>
     <Authors>Ziya Mollamahmut</Authors>
     <Company>Ziyad.info</Company>
@@ -13,12 +13,12 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageTags>asp.net, core, razor, mvc, taghelpers, taghelper,tag,helper,language,culture,dropdown, pagination, select, enum</PackageTags>
     <PackageReleaseNotes>
-      - Fixed issue related to TempData in AlertTagHelper. See: https://github.com/LazZiya/TagHelpers/issues/5
-      - removed support for .Net Core 1.x
+      - Support for dot net core 3.1.0
+      - PagingTagHelper : QueryStringValue is Obsolete, replaced by auto assigned ViewContext
     </PackageReleaseNotes>
-    <Version>3.0.2</Version>
-    <AssemblyVersion>3.0.2.0</AssemblyVersion>
-    <FileVersion>3.0.2.0</FileVersion>
+    <Version>3.1.0-preview1</Version>
+    <AssemblyVersion>3.1.0.0</AssemblyVersion>
+    <FileVersion>3.1.0.0</FileVersion>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseUrl></PackageLicenseUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/LazZiya/TagHelpers/master/LazZiya.TagHelpers/files/icon.png</PackageIconUrl>
@@ -29,20 +29,21 @@
     <DocumentationFile>files\LazZiya.TagHelpers.xml</DocumentationFile>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Localization" Version="1.0.0" Exclude="build,analyzers" />
-  </ItemGroup>
-  
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0' OR '$(TargetFramework)' == 'netcoreapp2.1' OR '$(TargetFramework)' == 'netcoreapp2.2'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="2.0.0" Exclude="build,analyzers" />
+    <PackageReference Include="Microsoft.AspNetCore.Localization" Version="2.0.0" Exclude="build,analyzers" />
+  </ItemGroup>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2'">
+    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.2.0" Exclude="Build,Analyzers" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" Version="3.0.0" Exclude="Build,Analyzers" />
   </ItemGroup>
   
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2'">
-    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.2.0" Exclude="Build,Analyzers" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" Version="3.1.0" Exclude="Build,Analyzers" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LazZiya.TagHelpers/LocalizationValidiationScriptsTagHelperComponent.cs
+++ b/LazZiya.TagHelpers/LocalizationValidiationScriptsTagHelperComponent.cs
@@ -13,7 +13,7 @@ namespace LazZiya.TagHelpers
     public class LocalizationValidationScriptsTagHelperComponent : TagHelperComponent
     {
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_0 || NETCOREAPP3_1
         private readonly IWebHostEnvironment _hosting;
 
         /// <summary>

--- a/LazZiya.TagHelpers/PagingTagHelper.cs
+++ b/LazZiya.TagHelpers/PagingTagHelper.cs
@@ -47,38 +47,38 @@ namespace LazZiya.TagHelpers
         /// <para>default: 1</para>
         /// <para>example: p=1</para>
         /// </summary>
-        public int PageNo { get; set; }
+        public int PageNo { get; set; } = 1;
 
         /// <summary>
         /// how many items to get from db per page per request
-        /// <para>default: 25</para>
-        /// <para>example: pageSize=25</para>
+        /// <para>default: 10</para>
+        /// <para>example: pageSize=10</para>
         /// </summary>
-        public int PageSize { get; set; }
+        public int PageSize { get; set; } = 10;
 
         /// <summary>
         /// Total count of records in the db
         /// <para>default: 0</para>
         /// </summary>
-        public int TotalRecords { get; set; }
+        public int TotalRecords { get; set; } = 0;
 
         /// <summary>
         /// if count of pages is too much, restrict shown pages count to specific number
         /// <para>default: 10</para>
         /// </summary>
-        public int MaxDisplayedPages { get; set; }
+        public int MaxDisplayedPages { get; set; } = 10;
 
         /// <summary>
         /// Gap size to start show first/last numbered page
-        /// <para>default: 5</para>
+        /// <para>default: 3</para>
         /// </summary>
-        public int GapSize { get; set; }
+        public int GapSize { get; set; } = 3;
 
         /// <summary>
         /// name of the settings section in appSettings.json
         /// <param>default: "default"</param>
         /// </summary>
-        public string SettingsJson { get; set; }
+        public string SettingsJson { get; set; } = "default";
 
         #endregion
 
@@ -88,25 +88,25 @@ namespace LazZiya.TagHelpers
         /// <para>default: get</para>
         /// <para>options: get, post</para>
         /// </summary>
-        public string PageSizeNavFormMethod { get; set; }
+        public string PageSizeNavFormMethod { get; set; } = "get";
 
         /// <summary>
         /// The minimum block size to populate all possible page sizes for dropdown list
-        /// <para>default: 25</para>
+        /// <para>default: 10</para>
         /// </summary>
-        public int PageSizeNavBlockSize { get; set; }
+        public int PageSizeNavBlockSize { get; set; } = 10;
 
         /// <summary>
         /// maximum nmber of items to show in the page size navigation menu
-        /// <para>default: 5</para>
+        /// <para>default: 3</para>
         /// </summary>
-        public int PageSizeNavMaxItems { get; set; }
+        public int PageSizeNavMaxItems { get; set; } = 3;
 
         /// <summary>
         /// action to take when page size dropdown changes
         /// <para>default: this.form.submit();</para>
         /// </summary>
-        public string PageSizeNavOnChange { get; set; }
+        public string PageSizeNavOnChange { get; set; } = "this.form.submit()";
 
         #endregion
 
@@ -117,14 +117,14 @@ namespace LazZiya.TagHelpers
         /// <para>default: p</para>
         /// <para>exmaple: p=1</para>
         /// </summary>
-        public string QueryStringKeyPageNo { get; set; }
+        public string QueryStringKeyPageNo { get; set; } = "p";
 
         /// <summary>
         /// Query string parameter name for page size
         /// <para>default: s</para>
         /// <para>example: s=25</para>
         /// </summary>
-        public string QueryStringKeyPageSize { get; set; }
+        public string QueryStringKeyPageSize { get; set; } = "s";
 
         /// <summary>
         /// query-string-value is obsolte and will be removed in a future release.
@@ -138,46 +138,46 @@ namespace LazZiya.TagHelpers
 
         /// <summary>
         /// Show drop down list for different page size options
-        /// <para>default: false</para>
+        /// <para>default: true</para>
         /// <para>options: true, false</para>
         /// </summary>
-        public bool? ShowPageSizeNav { get; set; }
+        public bool? ShowPageSizeNav { get; set; } = true;
 
         /// <summary>
         /// Show/hide First-Last buttons
-        /// <para>default: false, but will auto show if total pages > max displayed pages</para>
+        /// <para>default: true, if set to false and total pages > max displayed pages it will be true</para>
         /// </summary>
-        public bool? ShowFirstLast { get; set; }
+        public bool? ShowFirstLast { get; set; } = true;
 
         /// <summary>
         /// Show/hide Previous-Next buttons
-        /// <para>default: false</para>
+        /// <para>default: true</para>
         /// </summary>
-        public bool? ShowPrevNext { get; set; }
+        public bool? ShowPrevNext { get; set; } = true;
 
         /// <summary>
         /// Show or hide total pages count
-        /// <para>default: false</para>
+        /// <para>default: true</para>
         /// </summary>
-        public bool? ShowTotalPages { get; set; }
+        public bool? ShowTotalPages { get; set; } = true;
 
         /// <summary>
         /// Show or hide total records count
-        /// <para>default: false</para>
+        /// <para>default: true</para>
         /// </summary>
-        public bool? ShowTotalRecords { get; set; }
+        public bool? ShowTotalRecords { get; set; } = true;
 
         /// <summary>
         /// Show last numbered page when total pages count is larger than max displayed pages
-        /// <para>default: false</para>
+        /// <para>default: true</para>
         /// </summary>
-        public bool? ShowLastNumberedPage { get; set; }
+        public bool? ShowLastNumberedPage { get; set; } = true;
 
         /// <summary>
         /// Show first numbered page when total pages count is larger than max displayed pages
-        /// <para>default: false</para>
+        /// <para>default: true</para>
         /// </summary>
-        public bool? ShowFirstNumberedPage { get; set; }
+        public bool? ShowFirstNumberedPage { get; set; } = true;
 
         #endregion
 
@@ -483,19 +483,19 @@ namespace LazZiya.TagHelpers
             QueryStringKeyPageSize = QueryStringKeyPageSize ?? Configuration[$"lazziya:pagingTagHelper:{_settingsJson}:query-string-key-page-size"] ?? "s";
 
             ShowFirstLast = ShowFirstLast == null ?
-                bool.TryParse(Configuration[$"lazziya:pagingTagHelper:{_settingsJson}:show-first-last"], out bool _sfl) ? _sfl : false : ShowFirstLast;
+                bool.TryParse(Configuration[$"lazziya:pagingTagHelper:{_settingsJson}:show-first-last"], out bool _sfl) ? _sfl : true : ShowFirstLast;
 
-            ShowPrevNext = ShowPrevNext == null ? bool.TryParse(Configuration[$"lazziya:pagingTagHelper:{_settingsJson}:show-prev-next"], out bool _sprn) ? _sprn : false : ShowPrevNext;
+            ShowPrevNext = ShowPrevNext == null ? bool.TryParse(Configuration[$"lazziya:pagingTagHelper:{_settingsJson}:show-prev-next"], out bool _sprn) ? _sprn : true : ShowPrevNext;
 
-            ShowPageSizeNav = ShowPageSizeNav == null ? bool.TryParse(Configuration[$"lazziya:pagingTagHelper:{_settingsJson}:show-page-size-nav"], out bool _spsn) ? _spsn : false : ShowPageSizeNav;
+            ShowPageSizeNav = ShowPageSizeNav == null ? bool.TryParse(Configuration[$"lazziya:pagingTagHelper:{_settingsJson}:show-page-size-nav"], out bool _spsn) ? _spsn : true : ShowPageSizeNav;
 
-            ShowTotalPages = ShowTotalPages == null ? bool.TryParse(Configuration[$"lazziya:pagingTagHelper:{_settingsJson}:show-total-pages"], out bool _stp) ? _stp : false : ShowTotalPages;
+            ShowTotalPages = ShowTotalPages == null ? bool.TryParse(Configuration[$"lazziya:pagingTagHelper:{_settingsJson}:show-total-pages"], out bool _stp) ? _stp : true : ShowTotalPages;
 
-            ShowTotalRecords = ShowTotalRecords == null ? bool.TryParse(Configuration[$"lazziya:pagingTagHelper:{_settingsJson}:show-total-records"], out bool _str) ? _str : false : ShowTotalRecords;
+            ShowTotalRecords = ShowTotalRecords == null ? bool.TryParse(Configuration[$"lazziya:pagingTagHelper:{_settingsJson}:show-total-records"], out bool _str) ? _str : true : ShowTotalRecords;
 
-            ShowFirstNumberedPage = ShowFirstNumberedPage == null ? bool.TryParse(Configuration[$"lazziya:pagingTagHelper:{_settingsJson}:show-first-numbered-page"], out bool _sfp) ? _sfp : false : ShowFirstNumberedPage;
+            ShowFirstNumberedPage = ShowFirstNumberedPage == null ? bool.TryParse(Configuration[$"lazziya:pagingTagHelper:{_settingsJson}:show-first-numbered-page"], out bool _sfp) ? _sfp : true : ShowFirstNumberedPage;
 
-            ShowLastNumberedPage = ShowLastNumberedPage == null ? bool.TryParse(Configuration[$"lazziya:pagingTagHelper:{_settingsJson}:show-last-numbered-page"], out bool _slp) ? _slp : false : ShowLastNumberedPage;
+            ShowLastNumberedPage = ShowLastNumberedPage == null ? bool.TryParse(Configuration[$"lazziya:pagingTagHelper:{_settingsJson}:show-last-numbered-page"], out bool _slp) ? _slp : true : ShowLastNumberedPage;
 
             TextPageSize = TextPageSize ?? Configuration[$"lazziya:pagingTagHelper:{_settingsJson}:text-page-size"] ?? "Items per page";
 
@@ -558,8 +558,8 @@ namespace LazZiya.TagHelpers
 
         private Boundaries CalculateBoundaries(int currentPageNo, int totalPages, int maxDisplayedPages)
         {
-            var _start = 1;
-            var _end = maxDisplayedPages;
+            int _start, _end;
+
             var _gap = (int)Math.Ceiling(maxDisplayedPages / 2.0);
 
             if (maxDisplayedPages > totalPages)

--- a/LazZiya.TagHelpers/Utilities/GenericTempDataExtensions.cs
+++ b/LazZiya.TagHelpers/Utilities/GenericTempDataExtensions.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-#if NETCOREAPP3_0
+#if NETCOREAPP3_0 || NETCOREAPP3_1
 using System.Text.Json;
 #else
 using Newtonsoft.Json;
@@ -25,7 +25,7 @@ namespace LazZiya.TagHelpers.Utilities
         /// <param name="value"></param>
         public static void Put<T>(this ITempDataDictionary tempData, string key, T value) where T : class
         {
-#if NETCOREAPP3_0
+#if NETCOREAPP3_0 || NETCOREAPP3_1
             tempData[key] = JsonSerializer.Serialize(value);
 #else
             tempData[key] = JsonConvert.SerializeObject(value);
@@ -44,7 +44,7 @@ namespace LazZiya.TagHelpers.Utilities
             object o;
             tempData.TryGetValue(key, out o);
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_0 || NETCOREAPP3_1
             var obj = JsonSerializer.Deserialize<T>((string)o);
 #else
             var obj = JsonConvert.DeserializeObject<T>((string)o);

--- a/LazZiya.TagHelpers/Utilities/GenericTempDataExtensions.cs
+++ b/LazZiya.TagHelpers/Utilities/GenericTempDataExtensions.cs
@@ -41,8 +41,7 @@ namespace LazZiya.TagHelpers.Utilities
         /// <returns></returns>
         public static T Get<T>(this ITempDataDictionary tempData, string key) where T : class
         {
-            object o;
-            tempData.TryGetValue(key, out o);
+            tempData.TryGetValue(key, out object o);
 
 #if NETCOREAPP3_0 || NETCOREAPP3_1
             var obj = JsonSerializer.Deserialize<T>((string)o);

--- a/LazZiya.TagHelpers/files/LazZiya.TagHelpers.xml
+++ b/LazZiya.TagHelpers/files/LazZiya.TagHelpers.xml
@@ -262,7 +262,7 @@
         </member>
         <member name="P:LazZiya.TagHelpers.AlertTagHelper.ViewContext">
             <summary>
-            <para>ViewContext property is not required any more to be passed as parameter, you can remove it from the code.</para>
+            <para>ViewContext property is not required to be passed as parameter, it will be assigned automatically by the tag helper.</para>
             <para>View context is required to access TempData dictionary that contains the alerts coming from backend</para>
             </summary>
         </member>
@@ -394,7 +394,7 @@
         </member>
         <member name="P:LazZiya.TagHelpers.LanguageNavTagHelper.ViewContext">
             <summary>
-            <para>ViewContext property is not required any more to be passed as parameter, you can remove it from the code.</para>
+            <para>ViewContext property is not required to be passed as parameter, it will be auto assigned by the tag helpoer.</para>
             <para>current view context to access RouteData.Values and Request.Query collection</para>
             </summary>
         </member>
@@ -533,6 +533,12 @@
             Creates a pagination control
             </summary>
         </member>
+        <member name="P:LazZiya.TagHelpers.PagingTagHelper.ViewContext">
+            <summary>
+            <para>ViewContext property is not required to be passed as parameter, it will be assigned automatically by the tag helper.</para>
+            <para>View context is required to access TempData dictionary that contains the alerts coming from backend</para>
+            </summary>
+        </member>
         <member name="M:LazZiya.TagHelpers.PagingTagHelper.#ctor(Microsoft.Extensions.Configuration.IConfiguration,Microsoft.Extensions.Logging.ILogger{LazZiya.TagHelpers.PagingTagHelper})">
             <summary>
             Creates a pagination control
@@ -617,14 +623,7 @@
         </member>
         <member name="P:LazZiya.TagHelpers.PagingTagHelper.QueryStringValue">
             <summary>
-            Query string value starting from the ? including all next query string parameters 
-            to consider for next pages links.
-            <para>default: string.Empty</para>
-            <example>
-            <code>
-            @(Request.QueryString.Value)
-            </code>
-            </example>
+            query-string-value is obsolte and will be removed in a future release.
             </summary>
         </member>
         <member name="P:LazZiya.TagHelpers.PagingTagHelper.ShowPageSizeNav">
@@ -810,13 +809,12 @@
             </summary>
             <returns></returns>
         </member>
-        <member name="M:LazZiya.TagHelpers.PagingTagHelper.CreateUrlTemplate(System.Int32,System.Int32,System.String)">
+        <member name="M:LazZiya.TagHelpers.PagingTagHelper.CreateUrlTemplate(System.Int32,System.Int32)">
             <summary>
             edit the url for each page, so it navigates to its target page number
             </summary>
             <param name="pageNo"></param>
             <param name="pageSize"></param>
-            <param name="urlPath"></param>
             <returns></returns>
         </member>
         <member name="T:LazZiya.TagHelpers.PhoneNumberTagHelper">

--- a/LazZiya.TagHelpers/files/LazZiya.TagHelpers.xml
+++ b/LazZiya.TagHelpers/files/LazZiya.TagHelpers.xml
@@ -408,11 +408,10 @@
             required for listing supported cultures
             </summary>
         </member>
-        <member name="M:LazZiya.TagHelpers.LanguageNavTagHelper.#ctor(Microsoft.Extensions.Logging.ILogger{LazZiya.TagHelpers.LanguageNavTagHelper},Microsoft.Extensions.Options.IOptions{Microsoft.AspNetCore.Builder.RequestLocalizationOptions},Microsoft.AspNetCore.Routing.LinkGenerator,Microsoft.Extensions.Options.IOptions{Microsoft.AspNetCore.Mvc.MvcOptions})">
+        <member name="M:LazZiya.TagHelpers.LanguageNavTagHelper.#ctor(Microsoft.Extensions.Options.IOptions{Microsoft.AspNetCore.Builder.RequestLocalizationOptions},Microsoft.AspNetCore.Routing.LinkGenerator,Microsoft.Extensions.Options.IOptions{Microsoft.AspNetCore.Mvc.MvcOptions})">
             <summary>
             creates a language navigation menu, depends on supported cultures
             </summary>
-            <param name="logger"></param>
             <param name="ops">Request localization options</param>
             <param name="lg">link generator</param>
             <param name="mvcOps">MvcOptions</param>
@@ -554,8 +553,8 @@
         <member name="P:LazZiya.TagHelpers.PagingTagHelper.PageSize">
             <summary>
             how many items to get from db per page per request
-            <para>default: 25</para>
-            <para>example: pageSize=25</para>
+            <para>default: 10</para>
+            <para>example: pageSize=10</para>
             </summary>
         </member>
         <member name="P:LazZiya.TagHelpers.PagingTagHelper.TotalRecords">
@@ -573,7 +572,7 @@
         <member name="P:LazZiya.TagHelpers.PagingTagHelper.GapSize">
             <summary>
             Gap size to start show first/last numbered page
-            <para>default: 5</para>
+            <para>default: 3</para>
             </summary>
         </member>
         <member name="P:LazZiya.TagHelpers.PagingTagHelper.SettingsJson">
@@ -592,13 +591,13 @@
         <member name="P:LazZiya.TagHelpers.PagingTagHelper.PageSizeNavBlockSize">
             <summary>
             The minimum block size to populate all possible page sizes for dropdown list
-            <para>default: 25</para>
+            <para>default: 10</para>
             </summary>
         </member>
         <member name="P:LazZiya.TagHelpers.PagingTagHelper.PageSizeNavMaxItems">
             <summary>
             maximum nmber of items to show in the page size navigation menu
-            <para>default: 5</para>
+            <para>default: 3</para>
             </summary>
         </member>
         <member name="P:LazZiya.TagHelpers.PagingTagHelper.PageSizeNavOnChange">
@@ -629,44 +628,44 @@
         <member name="P:LazZiya.TagHelpers.PagingTagHelper.ShowPageSizeNav">
             <summary>
             Show drop down list for different page size options
-            <para>default: false</para>
+            <para>default: true</para>
             <para>options: true, false</para>
             </summary>
         </member>
         <member name="P:LazZiya.TagHelpers.PagingTagHelper.ShowFirstLast">
             <summary>
             Show/hide First-Last buttons
-            <para>default: false, but will auto show if total pages > max displayed pages</para>
+            <para>default: true, if set to false and total pages > max displayed pages it will be true</para>
             </summary>
         </member>
         <member name="P:LazZiya.TagHelpers.PagingTagHelper.ShowPrevNext">
             <summary>
             Show/hide Previous-Next buttons
-            <para>default: false</para>
+            <para>default: true</para>
             </summary>
         </member>
         <member name="P:LazZiya.TagHelpers.PagingTagHelper.ShowTotalPages">
             <summary>
             Show or hide total pages count
-            <para>default: false</para>
+            <para>default: true</para>
             </summary>
         </member>
         <member name="P:LazZiya.TagHelpers.PagingTagHelper.ShowTotalRecords">
             <summary>
             Show or hide total records count
-            <para>default: false</para>
+            <para>default: true</para>
             </summary>
         </member>
         <member name="P:LazZiya.TagHelpers.PagingTagHelper.ShowLastNumberedPage">
             <summary>
             Show last numbered page when total pages count is larger than max displayed pages
-            <para>default: false</para>
+            <para>default: true</para>
             </summary>
         </member>
         <member name="P:LazZiya.TagHelpers.PagingTagHelper.ShowFirstNumberedPage">
             <summary>
             Show first numbered page when total pages count is larger than max displayed pages
-            <para>default: false</para>
+            <para>default: true</para>
             </summary>
         </member>
         <member name="P:LazZiya.TagHelpers.PagingTagHelper.TextPageSize">

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@ Collection of helpful TagHelpers for any ASP.NET Core project.
 
 ## Latest release
 
-16 October 2019
-- v3.0.2
-- Fix for issue [#5](https://github.com/LazZiya/TagHelpers/issues/5)
-- Removed support for .Net core 1.x
+11 November 2019
+- v3.1.0-preview1
+- Supprt for DotnETcORE 3.1
+- PagingTagHelper : `query-string-value` not required to be passed as parameter, it will be assigned automatically by ViewContext in the tag helper.
 
 ## Contents
 - LocalizeTagHelper ([Repository](https://github.com/lazziya/TagHelpers.Localize), [Demo](http://demo.ziyad.info/en/Localize), [Tutorial](http://www.ziyad.info/en/articles/36-Develop_Multi_Cultural_Web_Application_Using_ExpressLocalization))
@@ -23,7 +23,7 @@ Collection of helpful TagHelpers for any ASP.NET Core project.
 Install via nuget :
 
 ````
-Install-Package LazZiya.TagHelpers -Version 3.0.2
+Install-Package LazZiya.TagHelpers -Version
 ````
 
 add tag helper to _ViewImports.cshtml:
@@ -33,6 +33,33 @@ add tag helper to _ViewImports.cshtml:
 ````
 
 # Code Samples
+
+## Paging TagHelper
+
+Only few parameters are required to fireup the agination control
+
+- version >= 3.1.0
+````razor
+<paging total-records="Model.TotalRecords"
+        page-no="Model.PageNo">
+</paging>
+````
+
+- version <= 3.0.2
+````razor
+<paging total-records="Model.TotalRecords"
+        page-no="Model.PageNo"
+        query-string-value="@(Request.QueryString.Value)">
+</paging>
+````
+
+it is important to add `query-string-value` for versions before 3.1.0.
+
+For more details :
+- [Docs](http://www.ziyad.info/en/articles/21-Paging_TagHelper_for_ASP_NET_Core)
+- [Demo](http://demo.ziyad.info/en/Paging)
+- [Step-by-step tutorial to build an efficient pagination system](http://www.ziyad.info/en/articles/38-How_to_build_an_efficient_pagination_system)
+
 ## Localize TagHelper
 Use simple html tag to localize text/html in razor views
 ````razor
@@ -80,6 +107,22 @@ Read more :
 - [Demo](http://demo.ziyad.info/en/Alerts)
 
 
+## LangaugeNav TagHelper
+
+- version >= 3.0.1
+````razor
+<language-nav></language-nav>
+````
+
+- version <= 3.0.0
+````cshtml
+<language-nav view-context="ViewContext"></language-nav>
+````
+For more details :
+- [Docs](http://www.ziyad.info/en/articles/32-Language_Navigation_TagHelper)
+- [Demo](http://demo.ziyad.info/en/LanguageNav)
+
+
 ## LocalizationValidationScripts TagHelper
 will add all required js files and code to validate localized input fields like numbers, date and currency. These scripts will help to validate localized decimal numbers with comma or dot format (e.g. EN culture: 1.2 - TR culture: 1,2).
 
@@ -95,22 +138,6 @@ will add all required js files and code to validate localized input fields like 
  For more details :
  - [Docs](http://www.ziyad.info/en/articles/34-Client_Side_Localization_Validation_Scripts)
  - [Demo](http://demo.ziyad.info/en/Trips)
-
-
-## LangaugeNav TagHelper
-
-- version >= 3.0.1
-````razor
-<language-nav></language-nav>
-````
-
-- version <= 3.0.0
-````cshtml
-<language-nav view-context="ViewContext"></language-nav>
-````
-For more details :
-- [Docs](http://www.ziyad.info/en/articles/32-Language_Navigation_TagHelper)
-- [Demo](http://demo.ziyad.info/en/LanguageNav)
 
 
 ## SelectEnum TagHelper
@@ -130,27 +157,6 @@ create the related select list dropdown in razor page :
 For more details :
 - [Docs](http://www.ziyad.info/en/articles/28-Select_Enum_TagHelper)
 - [Demo](http://demo.ziyad.info/en/SelectEnum)
-
-
-## Paging TagHelper
-
-Only few parameters are required to fireup the agination control
-
-````razor
-<paging total-records="Model.TotalRecords"
-        page-no="Model.PageNo"
-        query-string-value="@(Request.QueryString.Value)"
-        show-prev-next="true">
-</paging>
-````
-
-it is important to add `query-string-value` if there is multiple filtering parameters in the url.
-
-For more details :
-- [Docs](http://www.ziyad.info/en/articles/21-Paging_TagHelper_for_ASP_NET_Core)
-- [Demo](http://demo.ziyad.info/en/Paging)
-- [Step-by-step tutorial to build an efficient pagination system](http://www.ziyad.info/en/articles/38-How_to_build_an_efficient_pagination_system)
-
 
 ## Project site:
 http://ziyad.info/en/articles/27-LazZiya_TagHelpers

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Collection of helpful TagHelpers for any ASP.NET Core project.
 Install via nuget :
 
 ````
-Install-Package LazZiya.TagHelpers -Version
+Install-Package LazZiya.TagHelpers
 ````
 
 add tag helper to _ViewImports.cshtml:


### PR DESCRIPTION
- DotNet Core 3.1 support
- PagingTagHelper: all options are on by default, can be turned off manually
- PagingTagHelper: passing query-string-value as parameter is not required anymore