### PR TITLE
RenderMode Bootstrap 5

### DIFF
--- a/LazZiya.TagHelpers/LanguageNavModels.cs
+++ b/LazZiya.TagHelpers/LanguageNavModels.cs
@@ -53,7 +53,11 @@ namespace LazZiya.TagHelpers
         /// <summary>
         /// Render as form control
         /// </summary>
-        FormControl
+        FormControl,
+        /// <summary>
+        /// HTML5 div with Bootstrap 5 support
+        /// </summary>
+        Bootstrap5
     }
 
     internal class LanguageItem

--- a/LazZiya.TagHelpers/LanguageNavTagHelper.cs
+++ b/LazZiya.TagHelpers/LanguageNavTagHelper.cs
@@ -92,10 +92,13 @@ namespace LazZiya.TagHelpers
         {
             var langDictionary = CreateNavDictionary();
 
-            switch(RenderMode)
+            switch (RenderMode)
             {
                 case RenderMode.Bootstrap:
                     CreateBootstrapItems(ref output, langDictionary);
+                    break;
+                case RenderMode.Bootstrap5:
+                    CreateBootstrap5Items(ref output, langDictionary);
                     break;
                 case RenderMode.Classic:
                     CreateClassicItems(ref output, langDictionary);
@@ -208,6 +211,57 @@ namespace LazZiya.TagHelpers
         }
 
         /// <summary>
+        /// create classic list items list
+        /// <example><![CDATA[<a href="/en-US/Index" class="itemxyz">English</a>]]></example>
+        /// </summary>
+        /// <param name="langDictionary">language name-URL dictionary</param>
+        /// <param name="output">reference to TagHelperOuput</param>
+        /// <returns></returns>
+        private void CreateBootstrap5Items(ref TagHelperOutput output, List<LanguageItem> langDictionary)
+        {
+            var ul = new TagBuilder("ul");
+
+            if (CultureInfo.CurrentCulture.TextInfo.IsRightToLeft)
+                ul.AddCssClass("dropdown-menu dropdown-menu-left");
+            else
+                ul.AddCssClass("dropdown-menu dropdown-menu-right");
+
+            ul.Attributes.Add("aria-labeledby", "dropdownlang");
+
+            foreach (var lang in langDictionary.Where(x => x.Name != CultureInfo.CurrentCulture.Name).OrderBy(x => x.DisplayText))
+            {
+                var li = new TagBuilder("li");
+                var a = new TagBuilder("a");
+                a.AddCssClass("dropdown-item small");
+                a.Attributes.Add("href", lang.Url);
+
+                if (Flags)
+                {
+                    var flagName = lang.Name.Split('-');
+                    if (flagName.Length == 2)
+                    {
+                        if (FlagsSquared)
+                            a.InnerHtml.AppendHtml($"<span class=\"flag-icon flag-icon-{flagName[1].ToLowerInvariant()} flag-icon-squared\"></span>&nbsp;");
+                        else
+                            a.InnerHtml.AppendHtml($"<span class=\"flag-icon flag-icon-{flagName[1].ToLowerInvariant()}\"></span>&nbsp;");
+                    }
+                }
+
+                a.InnerHtml.Append(lang.DisplayText);
+                li.InnerHtml.AppendHtml(a);
+                ul.InnerHtml.AppendHtml(li);
+            }
+
+            output.TagName = "div";
+            output.Attributes.Add("class", "dropdown");
+
+            var toggle = CreateToggle5();
+            output.Content.AppendHtml(toggle);
+
+            output.Content.AppendHtml(ul);
+        }
+
+        /// <summary>
         /// create dictonary for all supported cultures
         /// <para>Key: Language display name for label</para>
         /// <para>Value: Navigation URL</para>
@@ -278,6 +332,36 @@ namespace LazZiya.TagHelpers
             toggle.Attributes.Add("href", "#");
             toggle.Attributes.Add("role", "button");
             toggle.Attributes.Add("data-toggle", "dropdown");
+            toggle.Attributes.Add("aria-haspopup", "true");
+            toggle.Attributes.Add("aria-expanded", "false");
+
+            var labelTxt = GetLanguageLabel(CultureInfo.CurrentCulture);
+
+            if (Flags)
+            {
+                var flagName = CultureInfo.CurrentCulture.Name.Split('-');
+                if (flagName.Length == 2)
+                {
+                    if (FlagsSquared)
+                        toggle.InnerHtml.AppendHtml($"<span class=\"flag-icon flag-icon-{flagName[1].ToLowerInvariant()} flag-icon-squared\"></span>&nbsp;");
+                    else
+                        toggle.InnerHtml.AppendHtml($"<span class=\"flag-icon flag-icon-{flagName[1].ToLowerInvariant()}\"></span>&nbsp;");
+                }
+            }
+
+            toggle.InnerHtml.AppendHtml(labelTxt);
+
+            return toggle;
+        }
+
+        private TagBuilder CreateToggle5()
+        {
+            var toggle = new TagBuilder("a");
+            toggle.AddCssClass("btn-sm btn-default border border-secondary dropdown-toggle");
+            toggle.Attributes.Add("id", "dropdownLang");
+            toggle.Attributes.Add("href", "#");
+            toggle.Attributes.Add("role", "button");
+            toggle.Attributes.Add("data-bs-toggle", "dropdown");
             toggle.Attributes.Add("aria-haspopup", "true");
             toggle.Attributes.Add("aria-expanded", "false");
 

--- a/LazZiya.TagHelpers/LazZiya.TagHelpers.xml
+++ b/LazZiya.TagHelpers/LazZiya.TagHelpers.xml
@@ -346,6 +346,11 @@
             Render as form control
             </summary>
         </member>
+        <member name="F:LazZiya.TagHelpers.RenderMode.Bootstrap5">
+            <summary>
+            HTML5 div with Bootstrap 5 support
+            </summary>
+        </member>
         <member name="T:LazZiya.TagHelpers.LanguageNavTagHelper">
             <summary>
             creates a language navigation menu, depends on supported cultures
@@ -441,6 +446,15 @@
             <returns></returns>
         </member>
         <member name="M:LazZiya.TagHelpers.LanguageNavTagHelper.CreateBootstrapItems(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperOutput@,System.Collections.Generic.List{LazZiya.TagHelpers.LanguageItem})">
+            <summary>
+            create classic list items list
+            <example><![CDATA[<a href="/en-US/Index" class="itemxyz">English</a>]]></example>
+            </summary>
+            <param name="langDictionary">language name-URL dictionary</param>
+            <param name="output">reference to TagHelperOuput</param>
+            <returns></returns>
+        </member>
+        <member name="M:LazZiya.TagHelpers.LanguageNavTagHelper.CreateBootstrap5Items(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperOutput@,System.Collections.Generic.List{LazZiya.TagHelpers.LanguageItem})">
             <summary>
             create classic list items list
             <example><![CDATA[<a href="/en-US/Index" class="itemxyz">English</a>]]></example>

--- a/TagHelpers.sln
+++ b/TagHelpers.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28729.10
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.31903.286
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LazZiya.TagHelpers", "LazZiya.TagHelpers\LazZiya.TagHelpers.csproj", "{080D63B6-33A9-47D5-99FF-F636542694EB}"
 EndProject
@@ -20,7 +20,7 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		BuildVersion_StartDate = 2000/1/1
 		SolutionGuid = {ED31C13F-823E-406C-87BA-4BC36A23816A}
+		BuildVersion_StartDate = 2000/1/1
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Hi @LazZiya ,

i tried to use the "language navigation" tag helper in a .Net core 6 web app (razor) and the dropdown did not expand/collapse as expected.
This new solution use bootstrap 5. In this version of bootstrap, the dropdown markup is a bit different :
- data attribute change to data-bs-toggle
- usage of ul and li tags

( https://getbootstrap.com/docs/5.1/components/dropdowns/ )

I made a quickfix : 
- add a new RenderMode : Bootstrap5
- handle Bootstrap5 in Process
- CreateToggle5 (fix data attribute)
- CreateBootstrap5Items (fix ul and li tags)

I hope it can help.

I have encountered the same behaviour with XLocalizer.DB.UI and Bootstrap 5.

Regards,

Ghislain
