### PR TITLE
Fixed Total badges for Bootstrap5

### DIFF
--- a/LazZiya.TagHelpers/PagingTagHelper.cs
+++ b/LazZiya.TagHelpers/PagingTagHelper.cs
@@ -603,9 +603,9 @@ namespace LazZiya.TagHelpers
 
             ClassPagingControl = ClassPagingControl ?? Configuration[$"lazziya:pagingTagHelper:{_settingsJson}:class-paging-control"] ?? "pagination";
 
-            ClassTotalPages = ClassTotalPages ?? Configuration[$"lazziya:pagingTagHelper:{_settingsJson}:class-total-pages"] ?? "badge badge-light";
+            ClassTotalPages = ClassTotalPages ?? Configuration[$"lazziya:pagingTagHelper:{_settingsJson}:class-total-pages"] ?? (RenderMode == RenderMode.Bootstrap ? "badge badge-light" : "badge bg-light text-dark");
 
-            ClassTotalRecords = ClassTotalRecords ?? Configuration[$"lazziya:pagingTagHelper:{_settingsJson}:class-total-records"] ?? "badge badge-dark";
+            ClassTotalRecords = ClassTotalRecords ?? Configuration[$"lazziya:pagingTagHelper:{_settingsJson}:class-total-records"] ?? (RenderMode == RenderMode.Bootstrap ? "badge badge-dark" : "badge bg-dark");
 
             ClassPageLink = ClassPageLink ?? Configuration[$"lazziya:pagingTagHelper:{_settingsJson}:class-page-link"] ?? "";
 


### PR DESCRIPTION
TotalPages and TotalRecords used the Bootstrap Badge with a background color.  Bootstrap5 changed the class from 'badge-light' to 'bg-light text-dark' and 'badge-dark' to 'bg-dark'
Reference:  https://getbootstrap.com/docs/5.1/components/badge/#background-colors